### PR TITLE
fix compute shader from Kode/Kinc 32fe1fc

### DIFF
--- a/Backends/Graphics4/OpenGL/Sources/kinc/backend/compute.c
+++ b/Backends/Graphics4/OpenGL/Sources/kinc/backend/compute.c
@@ -431,6 +431,11 @@ void kinc_compute_set_shader(kinc_compute_shader_t *shader) {
 #ifdef HAS_COMPUTE
 	glUseProgram(shader->impl._programid);
 	glCheckErrors();
+
+	for (int index = 0; index < shader->impl.textureCount; ++index) {
+		glUniform1i(shader->impl.textureValues[index], index);
+		glCheckErrors();
+	}
 #endif
 }
 


### PR DESCRIPTION
This pull request fixes https://github.com/Kode/Kinc/issues/851 and allows the use of compute shaders in Krom.