### PR TITLE
Fix rgba8 and support for compute shaders

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
 [submodule "Tools/windows_x64"]
 	path = Tools/windows_x64
-	url = https://github.com/Kode/KincTools_windows_x64.git
+	url = https://github.com/armory3d/KincTools_windows_x64.git
 	branch = main
 	shallow = true
 [submodule "Tools/macos"]
 	path = Tools/macos
-	url = https://github.com/Kode/KincTools_macos.git
+	url = https://github.com/armory3d/KincTools_macos.git
 	branch = main
 	shallow = true
 [submodule "Tools/linux_x64"]
 	path = Tools/linux_x64
-	url = https://github.com/Kode/KincTools_linux_x64.git
+	url = https://github.com/armory3d/KincTools_linux_x64.git
 	branch = main
 	shallow = true
 [submodule "Tools/linux_arm"]
 	path = Tools/linux_arm
-	url = https://github.com/Kode/KincTools_linux_arm.git
+	url = https://github.com/armory3d/KincTools_linux_arm.git
 	branch = main
 	shallow = true
 [submodule "Tools/linux_arm64"]
 	path = Tools/linux_arm64
-	url = https://github.com/Kode/KincTools_linux_arm64.git
+	url = https://github.com/armory3d/KincTools_linux_arm64.git
 	branch = main
 	shallow = true
 [submodule "Tools/freebsd_x64"]
 	path = Tools/freebsd_x64
-	url = https://github.com/Kode/KincTools_freebsd_x64.git
+	url = https://github.com/armory3d/KincTools_freebsd_x64.git
 	branch = main
 	shallow = true

--- a/Backends/Graphics4/OpenGL/Sources/kinc/backend/compute.c
+++ b/Backends/Graphics4/OpenGL/Sources/kinc/backend/compute.c
@@ -431,6 +431,11 @@ void kinc_compute_set_shader(kinc_compute_shader_t *shader) {
 #ifdef HAS_COMPUTE
 	glUseProgram(shader->impl._programid);
 	glCheckErrors();
+
+	for (int index = 0; index < shader->impl.textureCount; ++index) {
+		glUniform1i(shader->impl.textureValues[index], index);
+		glCheckErrors();
+	}
 #endif
 }
 

--- a/Backends/Graphics4/OpenGL/Sources/kinc/backend/graphics4/texture.c.h
+++ b/Backends/Graphics4/OpenGL/Sources/kinc/backend/graphics4/texture.c.h
@@ -109,6 +109,7 @@ static int convertInternalFormat(kinc_image_format_t format) {
 	case KINC_IMAGE_FORMAT_RGBA64:
 		return GL_RGBA16F_EXT;
 	case KINC_IMAGE_FORMAT_RGBA32:
+		return GL_RGBA8;
 	default:
 #ifdef KORE_IOS
 		return GL_RGBA;


### PR DESCRIPTION
This pull request fixes the RGBA32 texture format for 3D images and also fixes a bug with compute shaders: the uniforms weren't included.
These changes are officials and are needed to compile a Krom compatible with the new Voxels implementation.